### PR TITLE
refactor: quoteの認識の修正

### DIFF
--- a/lexer/new_ident_token.c
+++ b/lexer/new_ident_token.c
@@ -6,10 +6,26 @@ t_token	*new_ident_token(t_lexer *lexer)
 	char	*ident;
 	t_token	*token;
 	size_t	pos;
+	char	c;
 
 	pos = lexer->position;
+	c = 0;
 	while (!is_metachar(lexer->ch) && lexer->ch != '\0')
 	{
+		if (lexer->ch == '"' || lexer->ch == '\'')
+		{
+			c = lexer->ch;
+			read_char(lexer);
+			while (lexer->ch != c)
+			{
+				if (lexer->ch == '\0')
+				{
+					if (!join_new_line(lexer))
+						exit(EXIT_FAILURE);
+				}
+				read_char(lexer);
+			}
+		}
 		if (is_forbidden_char(lexer->ch))
 			exit(EXIT_FAILURE);
 		read_char(lexer);

--- a/lexer/next_token.c
+++ b/lexer/next_token.c
@@ -13,10 +13,6 @@ t_token	*next_token(t_lexer *lexer)
 		token = new_token(TOKEN_ILLEGAL, NULL);
 	else if (lexer->ch == '=')
 		token = new_token(TOKEN_ASSIGN, "=");
-	else if (lexer->ch == '\'' || lexer->ch == '"')
-	{
-		token = (new_quote_token(lexer, lexer->ch));
-	}
 	else if (lexer->ch == '>')
 	{
 		if (peek_char(lexer) == '>')

--- a/test/lexer_test.cpp
+++ b/test/lexer_test.cpp
@@ -119,3 +119,26 @@ TEST(lexer, env)
 	}
 	delete_lexer(lexer);
 }
+
+TEST(lexer, quote)
+{
+	char *input = ft_strdup("echo 'hello' \"hello\" joined'hello' joined\"hello\"");
+
+	std::vector<std::pair<t_tokentype, std::string>> expected = {
+		{TOKEN_IDENT, "echo"},
+		{TOKEN_IDENT, "'hello'"},
+		{TOKEN_IDENT, "\"hello\""},
+		{TOKEN_IDENT, "joined'hello'"},
+    {TOKEN_IDENT, "joined\"hello\""},
+		{TOKEN_EOF, ""},
+	};
+
+	t_lexer *lexer = new_lexer(input);
+	for (auto &expected_token : expected)
+	{
+		t_token *token = next_token(lexer);
+		compare_token(token, expected_token);
+		delete_token(token);
+	}
+	delete_lexer(lexer);
+}


### PR DESCRIPTION
# Issue

<!-- このPRの元になっているissueがあれば、それを書く -->

Closes #34

> `cat main.c` => `[IDENT, IDENT]`
`cat main".c"` => `[IDENT, IDENT, DQUOTE]` 
のように現状は認識している
>
> ただ、このTokenの分割方法だと、
`cat main".c"` => `[IDENT, IDENT, DQUOTE]` 
`cat main ".c"` => `[IDENT, IDENT, DQUOTE]` 
のように、両者を区別できない。
> 
> したがって、
`cat main.c` => `[IDENT, IDENT]`
`cat main".c"` => `[IDENT, IDENT]` 
`cat main ".c"` => `[IDENT, IDENT, IDENT]`
のように連続するIDENTとして認識するように変更する 