### PR TITLE
feat: heredoc内での環境変数の展開

### DIFF
--- a/lexer/lexer.h
+++ b/lexer/lexer.h
@@ -52,11 +52,12 @@ bool join_new_line(t_lexer *lexer);
 t_token *new_quote_token(t_lexer *lexer, t_tokentype type);
 bool is_word_token(t_tokentype);
 void add_heredoc_delimiter(t_lexer *lexer);
-void read_heredoc(t_lexer *lexer);
+void read_heredoc(t_lexer *lexer, t_list *env_list);
 void print_kvs(t_list *kvs);
 bool is_metachar(const char c);
 void word_split(t_list *lst);
 void expand_quote(void *input);
+char *expand_quote_str(const char *str);
 
 // helper
 char *replace_string(char *str, const char *from, const char *to);

--- a/lexer/read_heredoc.c
+++ b/lexer/read_heredoc.c
@@ -56,19 +56,28 @@ void	register_heredocs(t_lexer *lexer, char *buf)
 	ft_lstadd_back(&lexer->heredocs, ft_lstnew(kvs));
 }
 
-void	read_heredoc(t_lexer *lexer)
+void	read_heredoc(t_lexer *lexer, t_list *env_list)
 {
 	char	*buffer;
 	char	*tmp;
 	char	*line;
+	char	**delimiter;
+	bool has_quote;
 
+	delimiter = (char **)&(lexer->io_here_delimiters->content);
 	buffer = NULL;
+	has_quote = ft_strchr(*delimiter, '\'') != NULL || ft_strchr(*delimiter, '"') != NULL;
+	if (has_quote)
+	{
+		tmp = expand_quote_str(*delimiter);
+		free(*delimiter);
+		*delimiter = tmp;
+	}
 	line = readline("> ");
 	while (line != NULL)
 	{
-		if (ft_strncmp(line, (char *)lexer->io_here_delimiters->content,
-				ft_strlen(line)) == 0 &&
-			ft_strlen(line) == ft_strlen((char *)lexer->io_here_delimiters->content))
+		if (ft_strncmp(line, *delimiter, ft_strlen(line)) == 0 &&
+			ft_strlen(line) == ft_strlen(*delimiter))
 		{
 			free(line);
 			line = NULL;
@@ -82,6 +91,12 @@ void	read_heredoc(t_lexer *lexer)
 		free(buffer);
 		buffer = tmp;
 		line = readline("> ");
+	}
+	if (!has_quote)
+	{
+		tmp = expand_envvar_str(buffer, env_list);
+		free(buffer);
+		buffer = tmp;
 	}
 	register_heredocs(lexer, buffer);
 }

--- a/repl/start_repl.c
+++ b/repl/start_repl.c
@@ -64,7 +64,7 @@ void	start_repl(void)
 		}
 		while (lexer->io_here_delimiters != NULL)
 		{
-			read_heredoc(lexer);
+			read_heredoc(lexer, ea->env_lst);
 		}
 		if (ft_strlen(lexer->input) > 0) // 空文字列をヒストリーに入れないための対処法
 			add_history(lexer->input);


### PR DESCRIPTION
# Issue

<!-- このPRの元になっているissueがあれば、それを書く -->

Closes #63

## 要約

> If any part of word is quoted, the delimiter is the result of quote removal on word, and the lines in the here-document are not expanded. If word is unquoted, all lines of the here-document are subjected to parameter expansion, command substitution, and arithmetic expansion, the character sequence \newline is ignored, and ‘\’ must be used to quote the characters ‘\’, ‘$’, and ‘`’.

<!-- もし「やったこと」が長くなりそうなら、やったことの概要を3行以内でまとめる。なくても良い -->

- quoteが存在していたら、環境変数の展開が行われないようにした
- quoteが存在しない場合、環境変数の展開を行うようにした

