### PR TITLE
heredocのdelimiterが環境変数だった場合にcrashしていたのを修正

### DIFF
--- a/lexer/expand_envvar.c
+++ b/lexer/expand_envvar.c
@@ -87,7 +87,6 @@ void	update_flag(char c, bool *in_sq, bool *in_dq)
 	}
 }
 
-
 char	*expand_envvar_str(const char *input, void *env)
 {
 	char	*str;
@@ -104,7 +103,8 @@ char	*expand_envvar_str(const char *input, void *env)
 	while (str[i] != '\0')
 	{
 		update_flag(str[i], &in_sq, &in_dq);
-		if (str[i] == '$' && str[i + 1] != '\0' && (ft_isalpha(str[i+1]) || str[i+1] == '_') && !in_sq)
+		if (str[i] == '$' && str[i + 1] != '\0' && (ft_isalpha(str[i
+					+ 1]) || str[i + 1] == '_') && !in_sq)
 			process_single_envvar(&str, &i, env);
 		else
 			i++;
@@ -112,17 +112,31 @@ char	*expand_envvar_str(const char *input, void *env)
 	return (str);
 }
 
-void	expand_envvar(void *tokenp, void *envvar)
+void	expand_envvar(t_list *lst, t_list *env_lst)
 {
-	t_token *token;
 	char	*str;
+	t_token	*token;
+	bool	is_heredoc;
 
-	token = (t_token *)tokenp;
-	if (token->type == TOKEN_IDENT)
+	is_heredoc = false;
+	while (lst != NULL)
 	{
-		str = expand_envvar_str(token->literal, envvar);
-		free(token->literal);
-		token->literal = str;
+		token = lst->content;
+		if (token->type == TOKEN_IDENT)
+		{
+			if (is_heredoc)
+			{
+				is_heredoc = false;
+			}
+			else
+			{
+				str = expand_envvar_str(token->literal, env_lst);
+				free(token->literal);
+				token->literal = str;
+			}
+		}
+		if (token->type == TOKEN_HEREDOC)
+			is_heredoc = true;
+		lst = lst->next;
 	}
 }
-

--- a/lexer/lexer.h
+++ b/lexer/lexer.h
@@ -63,6 +63,6 @@ char *expand_quote_str(const char *str);
 char *replace_string(char *str, const char *from, const char *to);
 char *expand_single_envvar(char *str, const char *from, const char *to, size_t *i);
 char *expand_envvar_str(const char *input, void *env);
-void	expand_envvar(void *tokenp, void *envvar);
+void expand_envvar(t_list *lst, t_list *env_lst);
 
 #endif

--- a/lexer/print_token.c
+++ b/lexer/print_token.c
@@ -16,6 +16,8 @@ char *get_token_type_name(t_tokentype type)
 		return ("PIPE");
 	else if (type == TOKEN_IDENT)
 		return ("IDENT");
+	else if (type == TOKEN_HEREDOC)
+		return ("HEREDOC");
 	else
 		return ("UNKNOWN");
 }

--- a/libft/ft_lstiter.c
+++ b/libft/ft_lstiter.c
@@ -22,13 +22,3 @@ void	ft_lstiter(t_list *lst, void (*f)(void *))
 	}
 }
 
-void	ft_lstiter_with_var(t_list *lst, void (*f)(void *, void *), void *var)
-{
-	if (f == NULL)
-		return ;
-	while (lst != NULL)
-	{
-		f(lst->content, var);
-		lst = lst->next;
-	}
-}

--- a/parser/parse_cmd.c
+++ b/parser/parse_cmd.c
@@ -53,7 +53,10 @@ t_cmd	*parse_cmd(t_list *token_list, t_list **heredocs)
 		else if (token->type == TOKEN_HEREDOC)
 		{
 			token = token_list->next->content;
+			char *s = token->literal;
+			(void)s;
 			filename = ft_kvsget(*heredocs, token->literal);
+
 			printf("%s\n", filename);
 			ft_lstadd_back(&cmd->filenames_in, ft_lstnew(new_file(filename,
 							true)));

--- a/repl/start_repl.c
+++ b/repl/start_repl.c
@@ -69,9 +69,11 @@ void	start_repl(void)
 		if (ft_strlen(lexer->input) > 0) // 空文字列をヒストリーに入れないための対処法
 			add_history(lexer->input);
 		// print_tokens(token_list);
+		// print_tokens(token_list);
 		// print_kvs(lexer->heredocs);
 		// print_kvs(ea->env_lst);
-		ft_lstiter_with_var(token_list, expand_envvar, ea->env_lst);
+		expand_envvar(token_list, ea->env_lst);
+		// print_tokens(token_list);
 		// word_split(token_list);
 		ft_lstiter(token_list, &expand_quote);
 		// print_tokens(token_list);

--- a/test/expand_envvar_test.cpp
+++ b/test/expand_envvar_test.cpp
@@ -123,7 +123,7 @@ TEST(env, expand_envvar_wtf3)
 		{TOKEN_IDENT, "hoge\"'|wtf|'\""},
 		{TOKEN_EOF, ""},
 	};
-	ft_lstiter_with_var(input, expand_envvar, lst);
+	expand_envvar(input, lst);
 	compare_tokens(input, expected);
 	free(input);
 	free(key);


### PR DESCRIPTION
# Issue

<!-- このPRの元になっているissueがあれば、それを書く -->

Closes #

## 要約

<!-- もし「やったこと」が長くなりそうなら、やったことの概要を3行以内でまとめる。なくても良い -->

```bash
$ cat << $HOME
hoge
$HOME
```

としたときに、環境変数の展開がparserに渡る前に実行されていたため、`cat << /home/user` と認識されていた
したがって、`heredoc` を `/home/user` というkeyで検索することになり、`value`が存在せず、crashしていた

その点を修正

