### PR TITLE
fix: word splitting でquote を認識できるように修正

### DIFF
--- a/lexer/word_split.c
+++ b/lexer/word_split.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include "lexer.h"
 #include "libft.h"
 
@@ -13,11 +14,20 @@ void	ft_lstadd_next(t_list *lst, void *content)
 bool	has_whitespace(const char *str)
 {
 	size_t	i;
+	char is_quoted;
 
 	i = 0;
+	is_quoted = '\0';
 	while (str[i] != '\0')
 	{
-		if (ft_isspace(str[i]))
+		if (str[i] == '"' || str[i] == '\'')
+		{
+			if (is_quoted == '\0')
+				is_quoted = str[i];
+			else if (is_quoted == str[i])
+				is_quoted = '\0';
+		}
+		if (!is_quoted && ft_isspace(str[i]))
 			return (true);
 		i++;
 	}
@@ -28,15 +38,28 @@ char	*new_literal(const char *str, size_t *pos)
 {
 	size_t	i;
 	size_t	j;
+	char is_quoted;
 
 	i = 0;
-	while (ft_isspace(str[i]))
+	is_quoted = '\0';
+	while (str[i] != '\0')
+	{
+		if (str[i] == '"' || str[i] == '\'')
+		{
+			if (is_quoted == str[i])
+				is_quoted = '\0';
+			else if (is_quoted == '\0')
+				is_quoted = str[i];
+		}
+		if (!is_quoted && !ft_isspace(str[i]))
+			break;
 		i++;
+	}
 	j = 0;
 	while (str[i + j] != '\0' && !ft_isspace(str[i + j]))
 		j++;
 	*pos = i + j;
-	return (ft_substr(str, i, i + j));
+	return (ft_substr(str, i, j));
 }
 
 void	word_split(t_list *lst)
@@ -58,9 +81,15 @@ void	word_split(t_list *lst)
 						ft_strlen(token->literal));
 				free(token->literal);
 				token->literal = str;
-				token = new_token(TOKEN_IDENT, str_next);
-				free(str_next);
-				ft_lstadd_next(lst, token);
+				if (*str_next == '\0')
+				{
+					free(str_next);
+					str_next = NULL;
+				} else {
+					token = new_token(TOKEN_IDENT, str_next);
+					free(str_next);
+					ft_lstadd_next(lst, token);
+				}
 			}
 		}
 		lst = lst->next;

--- a/repl/start_repl.c
+++ b/repl/start_repl.c
@@ -79,15 +79,9 @@ void	start_repl(void)
 		}
 		if (ft_strlen(lexer->input) > 0) // 空文字列をヒストリーに入れないための対処法
 			add_history(lexer->input);
-		// print_tokens(token_list);
-		// print_tokens(token_list);
-		// print_kvs(lexer->heredocs);
-		// print_kvs(ea->env_lst);
 		expand_envvar(token_list, ea->env_lst);
-		// print_tokens(token_list);
-		// word_split(token_list);
+		word_split(token_list);
 		ft_lstiter(token_list, &expand_quote);
-		// print_tokens(token_list);
 		ea->cmd_lst = parse_pipe(token_list, &lexer->heredocs);
 		if (!is_valid_cmds(ea->cmd_lst))
 		{


### PR DESCRIPTION
# Issue

<!-- このPRの元になっているissueがあれば、それを書く -->

Closes #

## 要約

<!-- もし「やったこと」が長くなりそうなら、やったことの概要を3行以内でまとめる。なくても良い -->

- word splitting は実装されていたがバグがあった
- quoteで囲まれているときにもspaceが存在していたらsplitさせてしまっていた
- その点を修正した
