### PR TITLE
fix: 環境変数のvalueのスペースをtrim

### DIFF
--- a/self_cmd/self_export.c
+++ b/self_cmd/self_export.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   self_export.c                                      :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: mhirabay <mhirabay@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: tkirihar <tkirihar@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/04 16:53:41 by mhirabay          #+#    #+#             */
-/*   Updated: 2022/02/24 16:44:44 by mhirabay         ###   ########.fr       */
+/*   Updated: 2022/02/28 17:27:03 by tkirihar         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,6 +56,7 @@ void	export_with_args(t_cmd *cmd, t_exec_attr *ea)
 	int			ret;
 	char		*arg;
 	t_list		*lst;
+	char		*tmp_str;
 
 	lst = cmd->args->next;
 	while (lst != NULL)
@@ -98,6 +99,11 @@ void	export_with_args(t_cmd *cmd, t_exec_attr *ea)
 					if (kv[VALUE] == NULL)
 						abort_minishell_with(MALLOC_ERROR, ea, kv);
 				}
+				tmp_str = ft_strtrim(kv[VALUE], " ");
+				if (tmp_str == NULL)
+					abort_minishell_with(MALLOC_ERROR, ea, kv);
+				free(kv[VALUE]);
+				kv[VALUE] = tmp_str;
 				if (!store_arg_in_env(ea, kv[KEY], kv[VALUE]))
 					abort_minishell_with(MALLOC_ERROR, ea, kv);
 				if (!store_arg_in_export(ea, kv[KEY], kv[VALUE]))


### PR DESCRIPTION
# Issue

<!-- このPRの元になっているissueがあれば、それを書く -->

Closes #

## 要約

<!-- もし「やったこと」が長くなりそうなら、やったことの概要を3行以内でまとめる。なくても良い -->

- export_with_args関数のvalueの左右のスペースをtrimする処理を追加
-
-

## やったこと

<!-- やったことの詳細を書く -->

## 使用方法

<!-- もし他の人も使うコードを書いたなら、そのコードの使用方法を書く -->

## 注意点

<!-- レビュワーや、他の実装者が注意すべきポイントがあれば書く -->

## 参考にしたURL

<!-- 実装の参考にした記事のURLがあれば貼る -->

-
-
-

## かかった時間

<!-- かかった時間を0.5hr刻みで書く。ラベルをつけるのも忘れずに -->

n.m hr

## 詰まったところ

<!-- もし詰まったところがあれば書く（他の人の参考になるかもしれないので）。 -->

## 困っていること

<!-- 何か困っていることがあれば、それを書く -->
