### PR TITLE
env -i ./minishell によって環境変数を初期化してから実行した際にsegvになってしまうバグを修正

### DIFF
--- a/command/memo.md
+++ b/command/memo.md
@@ -13,3 +13,11 @@ export iのときに=""が入ってしまっている
 keyが存在しないときにvalueがkeyとして入ってしまっている
 OLDPWDが最初はNULL
 =がないvalueに更新をしたらちゃんと更新できる？
+
+env -iで初期化した場合、環境変数は以下
+```
+declare -x OLDPWD
+declare -x PWD="/Users/masashi/Projects/42tokyo/minishell/test/test_sh"
+declare -x SHLVL="1"
+```
+現在OLDPWD以外は実装できていない。

--- a/command/src/create_cmd.c
+++ b/command/src/create_cmd.c
@@ -6,7 +6,7 @@
 /*   By: mhirabay <mhirabay@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/08 16:40:07 by mhirabay          #+#    #+#             */
-/*   Updated: 2022/02/19 15:57:07 by mhirabay         ###   ########.fr       */
+/*   Updated: 2022/03/01 10:40:24 by mhirabay         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -162,8 +162,12 @@ char	*find_path(char *cmd_name, t_exec_attr *ea)
 	char			*env_path;
 	char			**path;
 	char			*new_cmd;
+	t_list			*lst;
 
-	env_path = ft_kvsget_value(get_lst_by_key(ea->env_lst, "PATH")->content);
+	lst = get_lst_by_key(ea->env_lst, "PATH");
+	if (lst == NULL)
+		return (NULL);
+	env_path = ft_kvsget_value(lst->content);
 	path = ft_split(env_path, ':');
 	if (path == NULL)
 		abort_minishell_with(MALLOC_ERROR, ea, path);

--- a/environ/lst_utils.c
+++ b/environ/lst_utils.c
@@ -6,7 +6,7 @@
 /*   By: mhirabay <mhirabay@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/07 13:27:06 by mhirabay          #+#    #+#             */
-/*   Updated: 2022/02/19 15:57:07 by mhirabay         ###   ########.fr       */
+/*   Updated: 2022/03/01 10:37:11 by mhirabay         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,6 +33,8 @@ void	sort_listkey_by_ascii(t_list *lst)
 	// 大文字アルファベット → _ → 小文字のアルファベットに並び替える
 	t_list	*min;
 
+	if (lst == NULL)
+		return ;
 	while (lst->next != NULL)
 	{
 		min = get_list_by_min_ascii_key(lst);

--- a/self_cmd/self_pwd.c
+++ b/self_cmd/self_pwd.c
@@ -6,7 +6,7 @@
 /*   By: mhirabay <mhirabay@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/02 14:54:57 by tkirihar          #+#    #+#             */
-/*   Updated: 2022/02/19 17:42:40 by mhirabay         ###   ########.fr       */
+/*   Updated: 2022/03/01 10:48:55 by mhirabay         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,14 +15,12 @@
 char	*x_getcwd(t_exec_attr *ea)
 {
 	char	*pathname;
+	t_list	*lst;
 
-	// TODO: getcwdは一応残しておく
-	// pathname = getcwd(NULL, 0);
-	// if (pathname == NULL)
-	// {
-		// pathnameがnullの場合、環境変数のPWDからとってきて表示する
-		pathname = ft_kvsget_value(get_lst_by_key(ea->env_lst, "PWD")->content);
-	// }
+	lst = get_lst_by_key(ea->env_lst, "PWD");
+	if (lst == NULL)
+		return (NULL);
+	pathname = ft_kvsget_value(lst->content);
 	return (pathname);
 }
 
@@ -32,6 +30,8 @@ int	exec_self_pwd(t_cmd *cmd, t_exec_attr *ea)
 
 	(void)cmd;
 	pathname = x_getcwd(ea);
+	if (pathname == NULL)
+		pathname = ea->current_pwd;
 	ft_putstr_fd(pathname, STDOUT_FILENO);
 	ft_putstr_fd("\n", STDOUT_FILENO);
 	return (0);


### PR DESCRIPTION
- 環境変数を入れる箇所でのsegv解決
- pwdコマンド実行におけるsegvの解決
- 外部コマンド実行におけるsegvの解決