### PR TITLE
cdのシンボリックリンク対応

### DIFF
--- a/command/sandbox/lstat_test.c
+++ b/command/sandbox/lstat_test.c
@@ -6,7 +6,7 @@
 /*   By: mhirabay <mhirabay@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/21 10:13:04 by mhirabay          #+#    #+#             */
-/*   Updated: 2022/02/21 10:38:36 by mhirabay         ###   ########.fr       */
+/*   Updated: 2022/03/02 15:51:25 by mhirabay         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -45,8 +45,9 @@ int main() {
       unlink(fn);
     }
     else {
-		lstat(sln, &buf);
+		int a = lstat(NULL, &buf);
 		lstat(fn, &buf_2);
+		printf("a = %d\n", a);
 		// printf("link = %d\n", buf_2.st_nlink);
 		printf("link = %d\n", S_ISLNK(buf_2.st_mode));
 		// printf("link = %d\n", buf.st_nlink);

--- a/command/src/no_pipe_process.c
+++ b/command/src/no_pipe_process.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   no_pipe_process.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tkirihar <tkirihar@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*   By: mhirabay <mhirabay@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/11 16:23:41 by tkirihar          #+#    #+#             */
-/*   Updated: 2022/02/28 15:32:23 by tkirihar         ###   ########.fr       */
+/*   Updated: 2022/03/02 16:29:30 by mhirabay         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -65,7 +65,9 @@ void	execute_ext_cmd(t_cmd *c, t_exec_attr *ea)
 			redirect(c, ea);
 		if (execve(cmd_path, cmdv, environ) == -1)
 		{
-			printf("exec error\n");
+			perror("exec error\n");
+			printf("cmd_path : %s\n", cmd_path);
+			print_array(cmdv);
 			exit(EXIT_FAILURE);
 		}
 		// こっちはいらないかもしれないけど一応


### PR DESCRIPTION
getcwdとパスを文字列としてつなげた値が異なっているとき、pwdで保存する値を文字列をつなげた値にするように実装しました。