### PR TITLE
feat:  `echo hoge > $NO_VAR` のような場合、t_file構造体のfileにNULLが入るようにした

### DIFF
--- a/lexer/expand_quote.c
+++ b/lexer/expand_quote.c
@@ -70,8 +70,11 @@ void	expand_quote(void *token_p)
 	token = (t_token *)token_p;
 	if (token->type == TOKEN_IDENT)
 	{
-		str = expand_quote_str(token->literal);
-		free(token->literal);
-		token->literal = str;
+		if (token->literal != NULL)
+		{
+			str = expand_quote_str(token->literal);
+			free(token->literal);
+			token->literal = str;
+		}
 	}
 }

--- a/parser/new_file.c
+++ b/parser/new_file.c
@@ -1,19 +1,23 @@
-#include "parser.h"
-#include "libft.h"
 #include "lexer.h"
+#include "libft.h"
+#include "parser.h"
 #include <stdbool.h>
 
-t_file *new_file(char *filename, bool is_double)
+t_file	*new_file(char *filename, bool is_double)
 {
-	t_file *file;
+	t_file	*file;
 
 	file = (t_file *)ft_calloc(sizeof(t_file), 1);
 	if (file == NULL)
 		exit(EXIT_FAILURE);
-	file->filename = ft_strdup(filename);
-	if (file->filename == NULL)
-		exit(EXIT_FAILURE);
+	if (filename != NULL)
+	{
+		file->filename = ft_strdup(filename);
+		if (file->filename == NULL)
+			exit(EXIT_FAILURE);
+	}
+	else
+		file->filename = NULL;
 	file->is_double = is_double;
 	return (file);
 }
-

--- a/parser/parse_exec.c
+++ b/parser/parse_exec.c
@@ -52,7 +52,8 @@ void	parse_exec(t_list *token_list, t_cmd **cmd_p)
 			cmd->is_invalid_syntax = true;
 			return ;
 		}
-		ft_lstadd_back(&cmd->args, ft_lstnew(get_literal(token)));
+		if (token->literal != NULL)
+			ft_lstadd_back(&cmd->args, ft_lstnew(get_literal(token)));
 		token_list = token_list->next;
 	}
 	if (cmd->args != NULL)

--- a/repl/start_repl.c
+++ b/repl/start_repl.c
@@ -37,7 +37,6 @@ void	start_repl(void)
 	t_lexer *lexer;
 	t_token *token;
 	t_list *token_list;
-	t_list *tmp;
 	t_exec_attr *ea;
 	char *line;
 	bool flag;
@@ -83,9 +82,9 @@ void	start_repl(void)
 			add_history(lexer->input);
 		expand_envvar(token_list, ea->env_lst);
 		word_split(token_list);
-		tmp = filter_null_literal_token(token_list);
-		ft_lstclear(&token_list, delete_token);
-		token_list = tmp;
+		// tmp = filter_null_literal_token(token_list);
+		// ft_lstclear(&token_list, delete_token);
+		// token_list = tmp;
 		ft_lstiter(token_list, &expand_quote);
 		ea->cmd_lst = parse_pipe(token_list, &lexer->heredocs);
 		if (!is_valid_cmds(ea->cmd_lst))

--- a/repl/start_repl.c
+++ b/repl/start_repl.c
@@ -82,9 +82,6 @@ void	start_repl(void)
 			add_history(lexer->input);
 		expand_envvar(token_list, ea->env_lst);
 		word_split(token_list);
-		// tmp = filter_null_literal_token(token_list);
-		// ft_lstclear(&token_list, delete_token);
-		// token_list = tmp;
 		ft_lstiter(token_list, &expand_quote);
 		ea->cmd_lst = parse_pipe(token_list, &lexer->heredocs);
 		if (!is_valid_cmds(ea->cmd_lst))


### PR DESCRIPTION
# Issue

<!-- このPRの元になっているissueがあれば、それを書く -->

Closes #

## 要約

<!-- もし「やったこと」が長くなりそうなら、やったことの概要を3行以内でまとめる。なくても良い -->

-
-
-

## やったこと

<!-- やったことの詳細を書く -->

## 使用方法

<!-- もし他の人も使うコードを書いたなら、そのコードの使用方法を書く -->

## 注意点

<!-- レビュワーや、他の実装者が注意すべきポイントがあれば書く -->

## 参考にしたURL

<!-- 実装の参考にした記事のURLがあれば貼る -->

- bashにおいて、 `echo hoge > $NO_VAR` を実行すると、`bash: $NO_VAR: ambiguous redirect` と出る
- `echo hoge > $NO_VAR | echo a` と打つと、`a` は正常に出力される
- これらのことから、parserで強制的に落とすのではなく、comand実行側に何らかの情報を渡してあげる必要が有る。
- 今回は、`t_file` の要素`filename`に`NULL` が入っている場合は`ambiguous` であるという方針にした

## かかった時間

<!-- かかった時間を0.5hr刻みで書く。ラベルをつけるのも忘れずに -->

n.m hr

## 詰まったところ

<!-- もし詰まったところがあれば書く（他の人の参考になるかもしれないので）。 -->

## 困っていること

<!-- 何か困っていることがあれば、それを書く -->
