### PR TITLE
fix: cmd が NULL のときのsyntax error を削除した

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,9 @@ SRCS_TEST = test/test_helper.cpp\
 			test/redirect_parser_test.cpp\
 			test/pipe_parser_test.cpp\
 
+test_sh: re
+	make -C test/test_sh
+
 .PHONY: test
 test: test-build
 	./tester

--- a/parser/parse_pipe.c
+++ b/parser/parse_pipe.c
@@ -8,23 +8,23 @@ t_list *parse_pipe_helper(t_list *token_list, t_list **heredocs);
 t_list *parse_pipe(t_list *token_list, t_list **heredocs)
 {
 	t_list *result;
-	t_list *tmp;
+	// t_list *tmp;
 
 	result = parse_pipe_helper(token_list, heredocs);
 	if (result == NULL)
 		return (NULL);
-	tmp = result;
-	while (tmp != NULL)
-	{
-		if (!is_valid_cmd(tmp->content))
-		{
-			printf("syntax error\n");
-			ft_lstclear(&result, delete_pipe);
-			result = NULL;
-			break;
-		}
-		tmp = tmp->next;
-	}
+	// tmp = result;
+	// while (tmp != NULL)
+	// {
+	// 	if (!is_valid_cmd(tmp->content))
+	// 	{
+	// 		printf("syntax error\n");
+	// 		ft_lstclear(&result, delete_pipe);
+	// 		result = NULL;
+	// 		break;
+	// 	}
+	// 	tmp = tmp->next;
+	// }
 	return (result);
 }
 

--- a/repl/start_repl.c
+++ b/repl/start_repl.c
@@ -84,12 +84,7 @@ void	start_repl(void)
 		word_split(token_list);
 		ft_lstiter(token_list, &expand_quote);
 		ea->cmd_lst = parse_pipe(token_list, &lexer->heredocs);
-		if (!is_valid_cmds(ea->cmd_lst))
-		{
-			printf("syntax error\n");
-			ft_lstclear(&token_list, delete_token);
-			continue;
-		}
+		print_cmds(ea->cmd_lst);
 		execute_cmd(ea);
 		ft_lstclear(&token_list, delete_token);
 		delete_lexer(lexer);

--- a/repl/start_repl.c
+++ b/repl/start_repl.c
@@ -84,7 +84,6 @@ void	start_repl(void)
 		word_split(token_list);
 		ft_lstiter(token_list, &expand_quote);
 		ea->cmd_lst = parse_pipe(token_list, &lexer->heredocs);
-		print_cmds(ea->cmd_lst);
 		execute_cmd(ea);
 		ft_lstclear(&token_list, delete_token);
 		delete_lexer(lexer);

--- a/test/test_sh/Makefile
+++ b/test/test_sh/Makefile
@@ -1,0 +1,2 @@
+all:
+	bash test.sh

--- a/test/test_sh/test.sh
+++ b/test/test_sh/test.sh
@@ -152,7 +152,7 @@ output_log () {
 }
 
 clean () {
-	find . -maxdepth 1 -type f | grep -v -E "cmd|test.sh|leaks.log|leaks.sh|${LOG_FILE_NAME}|exe|rb.c" | xargs rm
+	find . -maxdepth 1 -type f | grep -v -E "cmd|test.sh|leaks.log|leaks.sh|${LOG_FILE_NAME}|exe|rb.c|Makefile" | xargs rm
 }
 
 main () {


### PR DESCRIPTION
# Issue

<!-- このPRの元になっているissueがあれば、それを書く -->

Closes #

## 要約

<!-- もし「やったこと」が長くなりそうなら、やったことの概要を3行以内でまとめる。なくても良い -->

- `$NO_VAR` というコマンドを、syntax errorで弾いてしまっていた
- bash だと 改行が入力されたのと同等である。
- 弾かなように変更した

