### PR TITLE
fix: syntax error の修正 及び syntax error時にexit status を 2 にする

### DIFF
--- a/parser/parse_cmd.c
+++ b/parser/parse_cmd.c
@@ -15,43 +15,43 @@ t_cmd	*parse_cmd(t_list *token_list, t_list **heredocs)
 {
 	t_cmd	*cmd;
 	t_token	*token;
+	t_list *lst;
 	char	*filename;
 
 	cmd = cmd_init();
-	parse_exec(token_list, &cmd);
-	if (cmd->is_invalid_syntax)
-		return (cmd);
-	while (token_list != NULL)
+	lst = token_list;
+	while (lst != NULL)
 	{
-		token = token_list->content;
+		token = lst->content;
 		if (token->type == TOKEN_EOF || token->type == TOKEN_PIPE)
 			break ;
 		if (token->type == TOKEN_REDIRECT_IN)
 		{
-			token = token_list->next->content;
+			token = lst->next->content;
 			ft_lstadd_back(&cmd->filenames_in,
 							ft_lstnew(new_file(token->literal, false)));
 		}
 		else if (token->type == TOKEN_REDIRECT_OUT)
 		{
-			token = token_list->next->content;
+			token = lst->next->content;
 			ft_lstadd_back(&cmd->filenames_out,
 							ft_lstnew(new_file(token->literal, false)));
 		}
 		else if (token->type == TOKEN_REDIRECT_APPEND)
 		{
-			token = token_list->next->content;
+			token = lst->next->content;
 			ft_lstadd_back(&cmd->filenames_out,
 							ft_lstnew(new_file(token->literal, true)));
 		}
 		else if (token->type == TOKEN_HEREDOC)
 		{
-			token = token_list->next->content;
+			token = lst->next->content;
 			filename = ft_kvsget(*heredocs, token->literal);
 			ft_lstadd_back(&cmd->filenames_in, ft_lstnew(new_file(filename,
 							true)));
 		}
-		token_list = token_list->next;
+		lst = lst->next;
 	}
+	parse_exec(token_list, &cmd);
 	return (cmd);
 }

--- a/parser/parse_exec.c
+++ b/parser/parse_exec.c
@@ -3,6 +3,51 @@
 #include "libft.h"
 #include "parser.h"
 
+t_list	*filter_null_literal_cmd(t_list *lst)
+{
+	t_list	*res;
+	t_list	*now;
+	t_list	*tmp;
+	char	*literal;
+
+	if (lst == NULL)
+		return (NULL);
+	while (lst)
+	{
+		literal = lst->content;
+		if (literal != NULL)
+			break ;
+		lst = lst->next;
+	}
+	if (lst == NULL)
+		return (NULL);
+	now = ft_lstnew(ft_strdup(lst->content));
+	if (now == NULL)
+		return (NULL);
+	res = now;
+	while (lst->next != NULL)
+	{
+		literal = lst->next->content;
+		if (literal != NULL)
+		{
+			tmp = ft_lstnew(ft_strdup(literal));
+			if (tmp == NULL)
+			{
+				ft_lstclear(&res, free);
+				return (res);
+			}
+			now->next = tmp;
+			now = now->next;
+			lst = lst->next;
+		}
+		else
+		{
+			lst = lst->next;
+		}
+	}
+	return (res);
+}
+
 void	skip_redirect(t_list **token_list, t_cmd *cmd)
 {
 	t_token	*token;
@@ -28,6 +73,7 @@ void	parse_exec(t_list *token_list, t_cmd **cmd_p)
 {
 	t_token	*token;
 	t_cmd	*cmd;
+	t_list	*tmp;
 
 	if (cmd_p == NULL)
 		exit(EXIT_FAILURE);
@@ -52,10 +98,14 @@ void	parse_exec(t_list *token_list, t_cmd **cmd_p)
 			cmd->is_invalid_syntax = true;
 			return ;
 		}
-		if (token->literal != NULL)
-			ft_lstadd_back(&cmd->args, ft_lstnew(get_literal(token)));
+		ft_lstadd_back(&cmd->args, ft_lstnew(get_literal(token)));
 		token_list = token_list->next;
 	}
+	if (ft_lstsize(cmd->args) == 0 && ft_lstsize(cmd->filenames_in) == 0 && ft_lstsize(cmd->filenames_out) == 0)
+		cmd->is_invalid_syntax = true;
+	tmp = filter_null_literal_cmd(cmd->args);
+	ft_lstclear(&cmd->args, free);
+	cmd->args = tmp;
 	if (cmd->args != NULL)
 	{
 		cmd->cmd = ft_strdup(cmd->args->content);

--- a/parser/parse_pipe.c
+++ b/parser/parse_pipe.c
@@ -3,38 +3,25 @@
 #include "libft.h"
 #include "parser.h"
 
-t_list *parse_pipe_helper(t_list *token_list, t_list **heredocs);
+t_list	*parse_pipe_helper(t_list *token_list, t_list **heredocs);
 
-t_list *parse_pipe(t_list *token_list, t_list **heredocs)
+t_list	*parse_pipe(t_list *token_list, t_list **heredocs)
 {
-	t_list *result;
-	// t_list *tmp;
+	t_list	*result;
 
 	result = parse_pipe_helper(token_list, heredocs);
 	if (result == NULL)
 		return (NULL);
-	// tmp = result;
-	// while (tmp != NULL)
-	// {
-	// 	if (!is_valid_cmd(tmp->content))
-	// 	{
-	// 		printf("syntax error\n");
-	// 		ft_lstclear(&result, delete_pipe);
-	// 		result = NULL;
-	// 		break;
-	// 	}
-	// 	tmp = tmp->next;
-	// }
 	return (result);
 }
 
-t_list *parse_pipe_helper(t_list *token_list, t_list **heredocs)
+t_list	*parse_pipe_helper(t_list *token_list, t_list **heredocs)
 {
-	t_list *left_tokens;
-	t_list *right_tokens;
-	t_token *token;
-	t_list *lst;
-	t_cmd *cmd;
+	t_list	*left_tokens;
+	t_list	*right_tokens;
+	t_token	*token;
+	t_list	*lst;
+	t_cmd	*cmd;
 
 	left_tokens = token_list;
 	if (((t_token *)left_tokens->content)->type == TOKEN_EOF)
@@ -47,7 +34,7 @@ t_list *parse_pipe_helper(t_list *token_list, t_list **heredocs)
 	{
 		token = token_list->content;
 		if (token->type == TOKEN_EOF)
-			break;
+			break ;
 		if (token->type == TOKEN_PIPE)
 		{
 			right_tokens = token_list->next;

--- a/repl/start_repl.c
+++ b/repl/start_repl.c
@@ -64,7 +64,7 @@ void	start_repl(void)
 		}
 		if (!is_valid_tokens(token_list))
 		{
-			printf("syntax error\n");
+			write(STDERR, "syntax error\n", 13);
 			ft_lstclear(&token_list, delete_token);
 			continue;
 		}
@@ -84,6 +84,16 @@ void	start_repl(void)
 		word_split(token_list);
 		ft_lstiter(token_list, &expand_quote);
 		ea->cmd_lst = parse_pipe(token_list, &lexer->heredocs);
+		if (!is_valid_cmds(ea->cmd_lst))
+		{
+			write(STDERR, "syntax error\n", 13);
+			g_exit_status = 2;
+			ft_lstclear(&token_list, delete_token);
+			token_list = NULL;
+			ft_lstclear(&ea->cmd_lst, delete_pipe);
+			ea->cmd_lst = NULL;
+			continue;
+		}
 		execute_cmd(ea);
 		ft_lstclear(&token_list, delete_token);
 		delete_lexer(lexer);


### PR DESCRIPTION
# Issue

<!-- このPRの元になっているissueがあれば、それを書く -->

Closes #

## 要約

<!-- もし「やったこと」が長くなりそうなら、やったことの概要を3行以内でまとめる。なくても良い -->

- 環境変数のexpandを行うとき、 `$HOGE  |  echo` は正しく実行されるのに対し、 `| echo` はsyntax error となる
- `(ft_lstsize(cmd->args) == 0 && ft_lstsize(cmd->filenames_in) == 0 && ft_lstsize(cmd->filenames_out) == 0)` のとき、syntax error として処理するようにした
- ただし redirectの処理のあとにargsを処理し、その後syntaxの判定をして、argsのNULLを削除する、みたいに、順序が正しくないと動かないことに注意

## やったこと

<!-- やったことの詳細を書く -->

## 使用方法

<!-- もし他の人も使うコードを書いたなら、そのコードの使用方法を書く -->

## 注意点

<!-- レビュワーや、他の実装者が注意すべきポイントがあれば書く -->

