### PR TITLE
ダブルポインタの番兵をfreeするように修正

### DIFF
--- a/command/src/execute.c
+++ b/command/src/execute.c
@@ -4,7 +4,9 @@
 int	execute_cmd(t_exec_attr *ea)
 {
 	int	pipe_count;
+	// void *leak;
 
+	// leak = malloc(1);
 	if (ea->cmd_lst == NULL)
 		return (0);
 	pipe_count = ft_lstsize(ea->cmd_lst) - 1;

--- a/error_handle/error_handle.c
+++ b/error_handle/error_handle.c
@@ -41,6 +41,7 @@ void	free_char_dptr(char **dptr)
 			free(dptr[i]);
 			i++;
 		}
+		free(dptr[i]); // 番兵をfreeする
 		free(dptr);
 	}
 }


### PR DESCRIPTION
## 要約

<!-- もし「やったこと」が長くなりそうなら、やったことの概要を3行以内でまとめる。なくても良い -->

- free_char_dptr関数内で番兵をfreeする処理を追加
-
-
