### PR TITLE
fix: word splitting でquote を認識できるように修正

### DIFF
--- a/lexer/word_split.c
+++ b/lexer/word_split.c
@@ -9,23 +9,23 @@ char	*new_literal(const char *str, size_t *pos)
 	char	is_quoted;
 
 	i = 0;
+	while (str[i] != '\0' && ft_isspace(str[i]))
+		i++;
+	j = 0;
 	is_quoted = '\0';
-	while (str[i] != '\0')
+	while (str[i + j] != '\0')
 	{
-		if (str[i] == '"' || str[i] == '\'')
+		if (!is_quoted && ft_isspace(str[i + j]))
+			break ;
+		if (str[i + j] == '"' || str[i + j] == '\'')
 		{
-			if (is_quoted == str[i])
+			if (is_quoted == str[i + j])
 				is_quoted = '\0';
 			else if (is_quoted == '\0')
-				is_quoted = str[i];
+				is_quoted = str[i + j];
 		}
-		if (!is_quoted && !ft_isspace(str[i]))
-			break ;
-		i++;
-	}
-	j = 0;
-	while (str[i + j] != '\0' && !ft_isspace(str[i + j]))
 		j++;
+	}
 	*pos = i + j;
 	return (ft_substr(str, i, j));
 }

--- a/libft/ft_separate.c
+++ b/libft/ft_separate.c
@@ -16,7 +16,7 @@ char	**ft_separate(char *str, char separator)
 {
 	char *sep_ptr;
 	char **array;
-	
+
 	if (str == NULL)
 		return (NULL);
 	sep_ptr = ft_strchr(str, separator);

--- a/self_cmd/self_export.c
+++ b/self_cmd/self_export.c
@@ -58,7 +58,6 @@ void	export_with_args(t_cmd *cmd, t_exec_attr *ea, bool *exit_stat)
 	int			ret;
 	char		*arg;
 	t_list		*lst;
-	char		*tmp_str;
 
 	lst = cmd->args->next;
 	while (lst != NULL)
@@ -105,14 +104,6 @@ void	export_with_args(t_cmd *cmd, t_exec_attr *ea, bool *exit_stat)
 					kv[VALUE] = ft_strdup("");
 					if (kv[VALUE] == NULL)
 						abort_minishell_with(MALLOC_ERROR, ea, kv);
-				}
-				else
-				{
-					tmp_str = ft_strtrim(kv[VALUE], " ");
-					if (tmp_str == NULL)
-						abort_minishell_with(MALLOC_ERROR, ea, kv);
-					free(kv[VALUE]);
-					kv[VALUE] = tmp_str;
 				}
 				if (!store_arg_in_env(ea, kv[KEY], kv[VALUE]))
 					abort_minishell_with(MALLOC_ERROR, ea, kv);

--- a/test/lexer_test.cpp
+++ b/test/lexer_test.cpp
@@ -24,7 +24,7 @@ TEST(lexer, single_term)
 		{TOKEN_REDIRECT_IN, "<"},
 		{TOKEN_PIPE, "|"},
 		{TOKEN_IDENT, "$aaa"},
-		{TOKEN_EOF, ""},
+		{TOKEN_EOF, "NULL"},
 	};
 
 	t_lexer *lexer = new_lexer(input);
@@ -44,7 +44,7 @@ TEST(lexer, word)
 	std::vector<std::pair<t_tokentype, std::string>> expected = {
 		{TOKEN_IDENT, "echo"},
 		{TOKEN_IDENT, "hello"},
-		{TOKEN_EOF, ""},
+		{TOKEN_EOF, "NULL"},
 	};
 
 	t_lexer *lexer = new_lexer(input);
@@ -65,7 +65,7 @@ TEST(lexer, heredoc_append)
 		{TOKEN_REDIRECT_APPEND, ">>"},
 		{TOKEN_REDIRECT_IN, "<"},
 		{TOKEN_REDIRECT_OUT, ">"},
-		{TOKEN_EOF, ""},
+		{TOKEN_EOF, "NULL"},
 	};
 
 	t_lexer *lexer = new_lexer(input);
@@ -86,7 +86,7 @@ TEST(lexer, env)
 	std::vector<std::pair<t_tokentype, std::string>> expected = {
 		{TOKEN_IDENT, "$PATH"},
 		{TOKEN_IDENT, "$?"},
-		{TOKEN_EOF, ""},
+		{TOKEN_EOF, "NULL"},
 	};
 
 	t_lexer *lexer = new_lexer(input);
@@ -110,7 +110,7 @@ TEST(lexer, quote)
 		{TOKEN_IDENT, "\"hello\""},
 		{TOKEN_IDENT, "joined'hello'"},
 		{TOKEN_IDENT, "joined\"hello\""},
-		{TOKEN_EOF, ""},
+		{TOKEN_EOF, "NULL"},
 	};
 
 	t_lexer *lexer = new_lexer(input);

--- a/test/test_helper.cpp
+++ b/test/test_helper.cpp
@@ -20,7 +20,7 @@ void compare_token(t_token *token,
 				   std::pair<t_tokentype, std::string> expected_token)
 {
 	EXPECT_EQ(token->type, expected_token.first);
-	if (expected_token.second == "")
+	if (expected_token.second == "NULL")
 	{
 		EXPECT_STREQ(token->literal, NULL);
 	}

--- a/test/word_splitting_test.cpp
+++ b/test/word_splitting_test.cpp
@@ -30,13 +30,14 @@ TEST(word_split, regardless)
 		{TOKEN_EOF, ""},
 	};
 	word_split(input);
+	compare_tokens(input, expected_vector);
 	ft_lstclear(&input, &delete_token);
 }
 
 TEST(word_split, normal)
 {
 	std::vector<std::pair<t_tokentype, std::string>> input_vector = {
-		{TOKEN_IDENT, "echo hoge"},
+		{TOKEN_IDENT, "   echo    hoge   "},
 		{TOKEN_EOF, ""},
 	};
 	t_list *input = init_input_lists(input_vector);
@@ -44,9 +45,11 @@ TEST(word_split, normal)
 	std::vector<std::pair<t_tokentype, std::string>> expected_vector = {
 		{TOKEN_IDENT, "echo"},
 		{TOKEN_IDENT, "hoge"},
+		{TOKEN_IDENT, "NULL"},
 		{TOKEN_EOF, ""},
 	};
 	word_split(input);
+	compare_tokens(input, expected_vector);
 	ft_lstclear(&input, &delete_token);
 }
 
@@ -54,19 +57,59 @@ TEST(word_split, doubles)
 {
 	std::vector<std::pair<t_tokentype, std::string>> input_vector = {
 		{TOKEN_IDENT, "echo' 'hoge"},
-		{TOKEN_IDENT, "echo \"hoge"},
+		{TOKEN_IDENT, "echo\" \"hoge"},
 		{TOKEN_EOF, ""},
 	};
 	t_list *input = init_input_lists(input_vector);
 
 	std::vector<std::pair<t_tokentype, std::string>> expected_vector = {
-		{TOKEN_IDENT, "echo'"},
-		{TOKEN_IDENT, "'hoge"},
-		{TOKEN_IDENT, "echo"},
-		{TOKEN_IDENT, "\"hoge"},
+		{TOKEN_IDENT, "echo' 'hoge"},
+		{TOKEN_IDENT, "echo\" \"hoge"},
 		{TOKEN_EOF, ""},
 	};
 	word_split(input);
+	compare_tokens(input, expected_vector);
+	ft_lstclear(&input, &delete_token);
+}
+
+TEST(word_split, quote)
+{
+	std::vector<std::pair<t_tokentype, std::string>> input_vector = {
+		{TOKEN_IDENT, "\"echo\"   hoge    "},
+		{TOKEN_EOF, ""},
+	};
+	t_list *input = init_input_lists(input_vector);
+
+	std::vector<std::pair<t_tokentype, std::string>> expected_vector = {
+		{TOKEN_IDENT, "\"echo\""},
+		{TOKEN_IDENT, "hoge"},
+		{TOKEN_IDENT, "NULL"},
+		{TOKEN_EOF, ""},
+	};
+	word_split(input);
+	print_tokens(input);
+	compare_tokens(input, expected_vector);
+	ft_lstclear(&input, &delete_token);
+}
+
+
+TEST(word_split, quoted_space)
+{
+	std::vector<std::pair<t_tokentype, std::string>> input_vector = {
+		{TOKEN_IDENT, "\"    \"a   hoge    "},
+		{TOKEN_EOF, ""},
+	};
+	t_list *input = init_input_lists(input_vector);
+
+	std::vector<std::pair<t_tokentype, std::string>> expected_vector = {
+		{TOKEN_IDENT, "\"    \"a"},
+		{TOKEN_IDENT, "hoge"},
+		{TOKEN_IDENT, "NULL"},
+		{TOKEN_EOF, ""},
+	};
+	word_split(input);
+	print_tokens(input);
+	compare_tokens(input, expected_vector);
 	ft_lstclear(&input, &delete_token);
 }
 
@@ -80,14 +123,36 @@ TEST(word_split, operators)
 	t_list *input = init_input_lists(input_vector);
 
 	std::vector<std::pair<t_tokentype, std::string>> expected_vector = {
-		{TOKEN_IDENT, "echo'"},
-		{TOKEN_IDENT, "<<<'hoge"},
+		{TOKEN_IDENT, "echo' <<<'hoge"},
 		{TOKEN_IDENT, "echo"},
 		{TOKEN_IDENT, "||hoge"},
 		{TOKEN_IDENT, "@@xxx"},
 		{TOKEN_EOF, ""},
 	};
 	word_split(input);
+	print_tokens(input);
+	compare_tokens(input, expected_vector);
 	ft_lstclear(&input, &delete_token);
 }
 
+TEST(word_split, echo)
+{
+	std::vector<std::pair<t_tokentype, std::string>> input_vector = {
+		{TOKEN_IDENT, "echo"},
+		{TOKEN_IDENT, "\"a\"   test    "},
+		{TOKEN_EOF, ""},
+	};
+	t_list *input = init_input_lists(input_vector);
+
+	std::vector<std::pair<t_tokentype, std::string>> expected_vector = {
+		{TOKEN_IDENT, "echo"},
+		{TOKEN_IDENT, "\"a\""},
+		{TOKEN_IDENT, "test"},
+		{TOKEN_IDENT, "NULL"},
+		{TOKEN_EOF, ""},
+	};
+	word_split(input);
+	print_tokens(input);
+	compare_tokens(input, expected_vector);
+	ft_lstclear(&input, &delete_token);
+}


### PR DESCRIPTION
# Issue

<!-- このPRの元になっているissueがあれば、それを書く -->

Closes #172
Closes #174

## 要約

<!-- もし「やったこと」が長くなりそうなら、やったことの概要を3行以内でまとめる。なくても良い -->

- `export a="    aaa    "`  を実行すると、空白文字を含めて環境変数に登録されるように修正した
- `echo "a"$a"a" を実行すると、word splittingが行われ、`a aaa a` が出力されるように修正した
- #163 は**修正できていない**
